### PR TITLE
Fix: Add check for IMAGES_DEV binding in avatar upload

### DIFF
--- a/apps/api/src/routes/user/uploadAvatar.ts
+++ b/apps/api/src/routes/user/uploadAvatar.ts
@@ -76,18 +76,28 @@ export const registerUploadAvatar = (app: App) =>
 			const ext = fullName.split('.').pop()
 			const path = `images/${key}.${ext}`
 			try {
-				const image = await c.env.IMAGES_DEV.put(path, fileBuffer)
+				if (!c.env.IMAGES_DEV) {
+					throw new ApiError({
+						code: 'INTERNAL_SERVER_ERROR',
+						message: 'IMAGES_DEV R2 binding is not configured. Please check the environment configuration.',
+					});
+				}
+				const image = await c.env.IMAGES_DEV.put(path, fileBuffer);
 				return c.json(
 					{
 						key: `${image?.key}`,
 					},
 					201
-				)
+				);
 			} catch (error) {
+				// Handle the ApiError thrown above or other errors
+				if (error instanceof ApiError) {
+					throw error;
+				}
 				throw new ApiError({
 					code: 'INTERNAL_SERVER_ERROR',
 					message: `An error occurred while uploading the avatar. ${error instanceof Error ? error.message : 'Unknown error'}`,
-				})
+				});
 			}
 		} else {
 			throw new ApiError({


### PR DESCRIPTION
Adds a guard clause to the avatar upload route (`apps/api/src/routes/user/uploadAvatar.ts`) to verify the presence of the `c.env.IMAGES_DEV` R2 bucket binding.

If the binding is undefined, an ApiError is thrown with a specific message: "IMAGES_DEV R2 binding is not configured. Please check the environment configuration."

This change helps in providing a more informative error message if the R2 bucket is not correctly bound in the Cloudflare Workers environment, which is the likely cause of the "Cannot read properties of undefined (reading 'put')" error. The catch block was also updated to correctly re-throw any ApiError instances.