### PR TITLE
fix(audit): Set noEmit to false in tsconfig to allow build output

### DIFF
--- a/apps/audit/tsconfig.json
+++ b/apps/audit/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"rootDir": "src",
+		"noEmit": false, // Override the inherited noEmit: true
 		"module": "NodeNext", // or "CommonJS" if you prefer, but NodeNext is more modern for ESModules
 		"moduleResolution": "NodeNext",
 		"baseUrl": "./src",


### PR DESCRIPTION
The audit app's tsconfig.json was inheriting `noEmit: true` from the base workspace tsconfig, preventing `tsc` from outputting compiled files to the `dist` directory.

This change overrides `noEmit` to `false` in `apps/audit/tsconfig.json`, enabling the creation of the `dist` directory and allowing the `build` and `dev` scripts to function correctly.