### PR TITLE
feat(cerbos): Implement environment-aware Cerbos client initializer

### DIFF
--- a/apps/docs/docs/.vuepress/config.js
+++ b/apps/docs/docs/.vuepress/config.js
@@ -40,7 +40,7 @@ export default defineUserConfig({
 			},
 			{
 				text: 'Packages',
-				children: ['/packages/audit.md', '/packages/mailer.md'],
+				children: ['/packages/audit.md', '/packages/mailer.md', '/packages/cerbos.md'],
 			},
 		],
 	}),

--- a/apps/docs/docs/packages/cerbos.md
+++ b/apps/docs/docs/packages/cerbos.md
@@ -1,0 +1,153 @@
+---
+title: Cerbos Client (@repo/cerbos)
+---
+
+# Cerbos Client (`@repo/cerbos`)
+
+The `@repo/cerbos` package provides a convenient way to initialize and use the Cerbos client in different JavaScript environments. It automatically detects whether your code is running in a Cloudflare Workers environment or a Node.js environment and instantiates the appropriate Cerbos client (`HTTP` or `gRPC` respectively).
+
+## Overview
+
+Cerbos is a decoupled authorization layer. This package simplifies the integration of Cerbos into your applications by abstracting the client initialization logic.
+
+Key features:
+
+-   **Automatic Environment Detection**: Switches between `@cerbos/http` for Cloudflare Workers and `@cerbos/grpc` for Node.js.
+-   **Simplified Configuration**: Centralizes Cerbos PDP URL configuration.
+-   **Consistent API**: Provides a `getClient()` method that returns an instance compatible with `CerbosClient` from `@cerbos/core`.
+
+## Installation
+
+This package is designed for use within the monorepo. It relies on peer dependencies that should be present in the `packages/cerbos/package.json` file:
+
+-   `@cerbos/http`: For the HTTP client used in Cloudflare Workers.
+-   `@cerbos/grpc`: For the gRPC client used in Node.js.
+-   `@cerbos/core`: (Implicit) For shared types like `CerbosClient`.
+
+The versions for these dependencies are managed in `packages/cerbos/package.json`.
+
+## Configuration
+
+### Cerbos PDP URL
+
+The Cerbos client needs the URL of your Cerbos Policy Decision Point (PDP) instance. This can be configured in two ways, with the constructor argument taking precedence:
+
+1.  **Constructor Argument (Recommended for Clarity)**:
+    Pass the URL string as the first argument when creating a `Cerbos` instance.
+
+    ```typescript
+    import { Cerbos } from '@repo/cerbos';
+
+    const cerbosHttpUrl = 'http://127.0.0.1:3592'; // Standard Cerbos HTTP port
+    const cerbosGrpcUrl = '127.0.0.1:3593';     // Standard Cerbos gRPC port (without http/https scheme)
+
+    // For Cloudflare Workers (or any environment where HTTP is preferred)
+    const cerbosHttpInstance = new Cerbos(cerbosHttpUrl);
+
+    // For Node.js (or any environment where gRPC is preferred and available)
+    const cerbosGrpcInstance = new Cerbos(cerbosGrpcUrl);
+    ```
+
+2.  **Environment Variable**:
+    Set the `CERBOS_URL` environment variable. The `Cerbos` class will automatically pick it up if no URL is provided in the constructor.
+    -   **Node.js**: You can use a `.env` file (e.g., `CERBOS_URL=127.0.0.1:3593`) or set it in your shell.
+    -   **Cloudflare Workers**: Configure the `CERBOS_URL` variable in your `wrangler.toml` file or through the Cloudflare dashboard.
+
+    ```typescript
+    // Assuming CERBOS_URL is set in the environment
+    import { Cerbos } from '@repo/cerbos';
+    const cerbosInstance = new Cerbos();
+    ```
+
+If the URL is not provided via either method, the constructor will throw an error.
+
+## Usage
+
+1.  **Import the `Cerbos` class**:
+    ```typescript
+    import { Cerbos } from '@repo/cerbos';
+    ```
+
+2.  **Instantiate the `Cerbos` class**:
+    Provide the Cerbos PDP URL if not using the environment variable.
+    ```typescript
+    // Using environment variable
+    const cerbos = new Cerbos();
+
+    // Or, providing URL directly
+    // const cerbos = new Cerbos('http://localhost:3592'); // For HTTP
+    // const cerbos = new Cerbos('localhost:3593');    // For gRPC
+    ```
+
+3.  **Get the client instance**:
+    Use the `getClient()` method to get the underlying Cerbos client.
+    ```typescript
+    const cerbosClient = cerbos.getClient();
+    ```
+    The returned `cerbosClient` will be either an `HTTP` client or a `GRPC` client instance, both compatible with the `CerbosClient` interface from `@cerbos/core`.
+
+4.  **Interact with Cerbos**:
+    Use the client to make authorization checks, such as `checkResource`, `checkResources`, `planResources`, etc.
+
+    ```typescript
+    async function performCheck() {
+      try {
+        const decision = await cerbosClient.checkResource({
+          principal: {
+            id: 'alice',
+            roles: ['employee'],
+            attributes: { department: 'marketing' },
+          },
+          resource: {
+            kind: 'document',
+            id: 'xyz123',
+            attributes: { owner: 'bob', status: 'public' },
+          },
+          actions: ['view', 'comment'],
+        });
+
+        if (decision.isAllowed('view')) {
+          console.log('Alice is allowed to view the document.');
+        } else {
+          console.log('Alice is NOT allowed to view the document.');
+        }
+
+        if (decision.isAllowed('comment')) {
+          console.log('Alice is allowed to comment on the document.');
+        } else {
+          console.log('Alice is NOT allowed to comment on the document.');
+        }
+      } catch (error) {
+        console.error('Failed to check resource with Cerbos:', error);
+      }
+    }
+
+    performCheck();
+    ```
+
+## Environment Detection Details
+
+The `@repo/cerbos` package uses the following logic to determine the environment:
+
+-   **Cloudflare Workers**:
+    -   **Detection**: Checks for the global availability of `WebSocketPair` (i.e., `typeof WebSocketPair !== 'undefined'`).
+    -   **Client**: Initializes an `HTTP` client from `@cerbos/http`.
+    -   **URL Format**: Expects a standard HTTP/S URL (e.g., `http://localhost:3592`).
+
+-   **Node.js**:
+    -   **Detection**: Checks for the presence and properties of the global `process` object (i.e., `typeof process !== 'undefined' && process.versions != null && process.versions.node != null`).
+    -   **Client**: Initializes a `GRPC` client from `@cerbos/grpc`.
+    -   **URL Format**: Expects a host and port (e.g., `localhost:3593`).
+    -   **gRPC TLS**: By default, the gRPC client is instantiated with `tls: false`. For production environments or when connecting to a gRPC Cerbos PDP with TLS enabled, you would typically need to provide TLS configuration. This package currently does not expose options to configure gRPC TLS directly. If advanced gRPC configuration is needed, consider using `@cerbos/grpc` directly.
+
+-   **Unknown Environment**:
+    If neither environment is detected, the `Cerbos` constructor will throw an error, as it cannot determine which client to use.
+
+## Error Handling
+
+-   An error is thrown if the Cerbos URL is missing.
+-   An error is thrown if the environment cannot be identified.
+-   Standard errors from the `@cerbos/core`, `@cerbos/http`, or `@cerbos/grpc` clients may be thrown during operations (e.g., network issues, Cerbos PDP errors). Ensure you handle these appropriately in your application code.
+---
+
+This documentation should provide a comprehensive guide for users of the `@repo/cerbos` package.

--- a/packages/cerbos/README.md
+++ b/packages/cerbos/README.md
@@ -1,0 +1,87 @@
+# @repo/cerbos
+
+This package provides a Cerbos class that automatically initializes the correct Cerbos client based on the runtime environment. It uses the HTTP client for Cloudflare Workers and the gRPC client for Node.js environments.
+
+This allows for a unified way to interact with Cerbos policies across different parts of your application stack that might run in varying JavaScript environments.
+
+## Installation
+
+This package is intended to be used as part of a monorepo. Ensure that its peer dependencies are met:
+
+```json
+"dependencies": {
+  "@cerbos/grpc": "^0.22.0",
+  "@cerbos/http": "0.22.0"
+}
+```
+(And `@cerbos/core` is implicitly required for types).
+
+## Usage
+
+First, ensure that your Cerbos PDP is running and accessible.
+
+You need to provide the Cerbos PDP URL. This can be done in two ways:
+
+1.  **Environment Variable**: Set the `CERBOS_URL` environment variable.
+    *   For Node.js, this can be in a `.env` file (e.g., `CERBOS_URL=localhost:3593` for local gRPC).
+    *   For Cloudflare Workers, configure this in your `wrangler.toml` or via the Cloudflare dashboard.
+2.  **Constructor Argument**: Pass the URL directly when creating an instance of the `Cerbos` class. This will override any environment variable.
+
+```typescript
+import { Cerbos } from '@repo/cerbos';
+
+// Option 1: Using environment variable CERBOS_URL
+// Ensure CERBOS_URL is set in your environment.
+// e.g., CERBOS_URL=http://localhost:3592 (for HTTP) or CERBOS_URL=localhost:3593 (for gRPC)
+const cerbosInstanceEnv = new Cerbos();
+const cerbosClientEnv = cerbosInstanceEnv.getClient();
+
+// Option 2: Providing URL directly in the constructor
+const cerbosPdpUrl = 'http://localhost:3592'; // Or 'localhost:3593' for gRPC
+const cerbosInstanceDirect = new Cerbos(cerbosPdpUrl);
+const cerbosClientDirect = cerbosInstanceDirect.getClient();
+
+// Now you can use the cerbosClient to interact with the Cerbos PDP
+// For example, to check permissions:
+async function checkAccess() {
+  try {
+    const decision = await cerbosClientDirect.checkResource({
+      principal: {
+        id: "user123",
+        roles: ["USER"],
+        attributes: { department: "engineering" },
+      },
+      resource: {
+        kind: "document",
+        id: "doc456",
+        attributes: { owner: "user123", status: "draft" },
+      },
+      actions: ["view", "edit"],
+    });
+
+    if (decision.isAllowed("view")) {
+      console.log("User is allowed to view the document.");
+    } else {
+      console.log("User is NOT allowed to view the document.");
+    }
+
+    if (decision.isAllowed("edit")) {
+      console.log("User is allowed to edit the document.");
+    } else {
+      console.log("User is NOT allowed to edit the document.");
+    }
+  } catch (error) {
+    console.error("Error checking resource with Cerbos:", error);
+  }
+}
+
+checkAccess();
+```
+
+## Environment Detection
+
+-   **Cloudflare Workers**: Detected by the presence of `WebSocketPair`. Initializes `HTTP` client from `@cerbos/http`.
+-   **Node.js**: Detected by the presence of `process.versions.node`. Initializes `GRPC` client from `@cerbos/grpc`.
+    -   By default, the gRPC client is initialized with `tls: false`. If you need to connect to a gRPC Cerbos instance with TLS enabled, you will need to modify the client instantiation logic or use the `@cerbos/grpc` client directly with appropriate options.
+
+If the environment cannot be determined, an error will be thrown during instantiation.

--- a/packages/cerbos/package.json
+++ b/packages/cerbos/package.json
@@ -28,6 +28,7 @@
 		"@repo/tools": "workspace:*",
 		"@repo/typescript-config": "workspace:*",
 		"@types/node": "24.0.4",
-		"vitest": "3.2.4"
+		"vitest": "3.2.4",
+		"@cerbos/core": "^0.22.0"
 	}
 }

--- a/packages/cerbos/src/index.ts
+++ b/packages/cerbos/src/index.ts
@@ -1,47 +1,84 @@
 /**
- * Cerbos
+ * Cerbos Client Initializer
+ *
+ * This package provides a Cerbos class that automatically initializes the correct
+ * Cerbos client based on the runtime environment. It uses the HTTP client for
+ * Cloudflare Workers and the gRPC client for Node.js environments.
  *
  * @example
  *
  * Use from other apps/packages:
  *
  * ```ts
- * import { Cerbos } from '@repo/cerbos'
+ * import { Cerbos } from '@repo/cerbos';
  *
- * const cerbos = new Cerbos()
+ * // The CERBOS_URL environment variable will be used if not provided in the constructor
+ * const cerbosInstance = new Cerbos();
+ * const cerbosClient = cerbosInstance.getClient();
+ *
+ * // Now you can use cerbosClient to interact with the Cerbos PDP
+ * // E.g., cerbosClient.checkResource({ ... });
  * ```
  */
-import { GRPC } from '@cerbos/grpc'
-import { HTTP } from '@cerbos/http'
+import { GRPC } from '@cerbos/grpc';
+import { HTTP } from '@cerbos/http';
+import type { CerbosClient } from '@cerbos/core';
 
 // Helper to try and get env variables from Cloudflare Workers or Node.js process.env
 function getEnv(variableName: string): string | undefined {
-	// Check Cloudflare Workers env
-	// @ts-expect-error Hides `Cannot find name 'env'.` when not in CF Worker context.
-	if (typeof env !== 'undefined' && env[variableName]) {
+	// Check Cloudflare Workers env (this is a common way, but might need adjustment based on actual CF worker env structure)
+	// @ts-expect-error Hides `Cannot find name 'env'.` when not in CF Worker context. KV bindings are usually on `env`
+	if (typeof WebSocketPair !== 'undefined' && typeof env !== 'undefined' && env && env[variableName]) {
 		// @ts-expect-error
-		return env[variableName]
+		return env[variableName];
 	}
 	// Check Node.js process.env
 	if (typeof process !== 'undefined' && process.env && process.env[variableName]) {
-		return process.env[variableName]
+		return process.env[variableName];
 	}
-	return undefined
+	return undefined;
 }
 
+// Environment detection functions
+const isCloudflareWorkers = (): boolean => typeof WebSocketPair !== 'undefined';
+const isNodeJS = (): boolean => typeof process !== 'undefined' && process.versions != null && process.versions.node != null;
+
 export class Cerbos {
+	private client: CerbosClient;
+
 	/**
-	 * Constructs an Cerbos instance (http for Cloudflare Workers and grpc for Node.js environment).
-	 * @param cerbosUrl Optional. The Cerbos connection URL. If not provided, it attempts to use
-	 *                 `env.CERBOS_URL` (for Cloudflare Workers) or `process.env.CERBOS_URL` (for Node.js).
+	 * Constructs a Cerbos instance, automatically selecting the appropriate client
+	 * (HTTP for Cloudflare Workers, gRPC for Node.js environment).
+	 * @param cerbosUrl Optional. The Cerbos PDP connection URL. If not provided, it attempts to use
+	 *                 the `CERBOS_URL` environment variable.
+	 * @throws Error if the Cerbos URL is not provided and cannot be found in environment variables.
+	 * @throws Error if the environment is not recognized as Cloudflare Workers or Node.js.
 	 */
 	constructor(cerbosUrl?: string) {
-		const effectiveCerbosUrl = cerbosUrl || getEnv('CERBOS_URL')
+		const effectiveCerbosUrl = cerbosUrl || getEnv('CERBOS_URL');
 
 		if (!effectiveCerbosUrl) {
 			throw new Error(
-				'Cerbos Service: Cerbos URL not provided and could not be found in environment variables (ACERBOS_URL).'
-			)
+				'Cerbos Service: Cerbos URL not provided and could not be found in environment variables (CERBOS_URL).'
+			);
 		}
+
+		if (isCloudflareWorkers()) {
+			this.client = new HTTP(effectiveCerbosUrl);
+		} else if (isNodeJS()) {
+			this.client = new GRPC(effectiveCerbosUrl, { tls: false }); // Assuming local development often uses non-TLS gRPC. Adjust as needed.
+		} else {
+			throw new Error(
+				'Cerbos Service: Unrecognized environment. Cannot determine whether to use HTTP or gRPC client.'
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the initialized Cerbos client instance (either HTTP or gRPC).
+	 * @returns The CerbosClient instance.
+	 */
+	public getClient(): CerbosClient {
+		return this.client;
 	}
 }


### PR DESCRIPTION
Introduces a new `Cerbos` class in `@repo/cerbos` that automatically detects the runtime environment (Cloudflare Workers or Node.js) and initializes the appropriate Cerbos client (HTTP or gRPC respectively).

- The client URL can be provided via the `CERBOS_URL` environment variable or directly to the constructor.
- Added `getClient()` method to retrieve the underlying client instance.
- Included README.md for the package.
- Added detailed documentation in `apps/docs/docs/packages/cerbos.md` and updated VuePress sidebar configuration.
- Added `@cerbos/core` to devDependencies for type information.