### PR TITLE
Fix: Correct misleading error message in AppDb

### DIFF
--- a/packages/app-db/src/db/index.ts
+++ b/packages/app-db/src/db/index.ts
@@ -37,7 +37,7 @@ export class AppDb {
 
 		if (!effectivePostgresUrl) {
 			throw new Error(
-				'AuditDb: PostgreSQL connection URL not provided and could not be found in environment variables (AUDIT_DB_URL).'
+				'AppDb: PostgreSQL connection URL not provided (postgresUrl parameter) and could not be found in environment variables (APP_DB_URL).'
 			)
 		}
 		this.client = postgres(effectivePostgresUrl)


### PR DESCRIPTION
The AppDb service was displaying an error message that incorrectly referred to 'AuditDb' and 'AUDIT_DB_URL' when it should have referred to 'AppDb' and 'APP_DB_URL'. This change corrects the error message string to accurately reflect the service and environment variable it requires.

This addresses confusion where issues with AppDb's configuration could be misinterpreted as problems with the AuditDb setup.