### PR TITLE
Fix: Attempt to resolve sidebar content overlap

### DIFF
--- a/apps/web/src/components/dashboard/app-sidebar.tsx
+++ b/apps/web/src/components/dashboard/app-sidebar.tsx
@@ -195,10 +195,12 @@ export function AppSidebar({ isMobile = false }: { isMobile?: boolean }) {
 			<Sidebar
 				className={cn(
 					'bg-background border-r overflow-hidden',
-					isMobile ? 'p-3 pt-12 w-full h-full' : 'p-4 w-72 fixed left-0 top-0 z-40 h-screen',
+					isMobile ? 'p-3 pt-12 w-full h-full' : 'fixed left-0 top-0 z-40 h-screen', // Removed p-4 and w-72 for non-mobile
 					!isMobile && 'hidden md:flex md:flex-col'
 				)}
 				collapsible="none"
+				variant="inset" // Added variant="inset"
+				style={{ '--sidebar-width': '18rem' } as React.CSSProperties} // Ensure gap matches w-72
 				data-testid="app-sidebar"
 			>
 				{/* ---------- header ---------- */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./apps/web/src/**/*.{js,ts,jsx,tsx,html}",
+    "./packages/ui/src/**/*.{js,ts,jsx,tsx,html}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
Includes:
- Setting variant='inset' on AppSidebar's Sidebar component.
- Overriding '--sidebar-width' to '18rem' in AppSidebar.
- Simplifying classNames on AppSidebar's Sidebar component.
- Adding a root tailwind.config.js for explicit monorepo content scanning.

Note: The core sidebar overlap issue remains unresolved. These changes represent attempts to fix it based on component analysis. Further investigation into the Tailwind build process or potential environment-specific CSS conflicts is likely needed.