### PR TITLE
Fix(test): Update send-mail and audit tests for shared Redis and othe…

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -89,6 +89,11 @@
 			"outputLogs": "new-only",
 			"outputs": ["node_modules/.cache/eslint/.eslintcache"], // Adjusted path
 			"env": ["FIX_ESLINT"]
+		},
+		"test": {
+			"dependsOn": ["^build", "topo"],
+			"outputs": [],
+			"outputLogs": "new-only"
 		}
 		// "fix:workers-types": {} // Removed Cloudflare-specific task
 	}


### PR DESCRIPTION
…r changes

- Modified send-mail and audit tests to reflect that services now default to a shared Redis connection instead of throwing an error when no URL is provided.
- Updated numerous test expectations in both packages to align with recent changes in source code, including:
  - Telemetry options for BullMQ Queue constructor (send-mail).
  - Specific wording in log messages and error messages, particularly for direct Redis connections.
  - BullMQ queue 'add' options (removeOnFail).
- Adjusted ioredis mock in audit.test.ts to correctly handle default exports and provide necessary mock methods (e.g., disconnect), resolving issues with spy verification and mock implementations.
- Refined Redis connection logic in the Audit service constructor to correctly prioritize direct connections via environment variables before falling back to the shared connection.
- Added a 'test' task definition to the root turbo.jsonc to ensure Turbo can correctly discover and run package-level test scripts.