### PR TITLE
Add clean scripts to package.json files for consistent project cleanup

### DIFF
--- a/apps/ai/package.json
+++ b/apps/ai/package.json
@@ -11,6 +11,7 @@
 		"build": "mastra build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf node_modules .mastra",
 		"dev": "mastra dev"
 	},
 	"dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
 		"build": "tsc",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"dev": "concurrently \"tsc -w\" \"nodemon dist/index.js\"",
 		"dev:vite": "vite --port 8801",
 		"test": "run-vitest"

--- a/apps/audit/package.json
+++ b/apps/audit/package.json
@@ -9,6 +9,7 @@
 		"build": "tsc",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"dev": "concurrently \"tsc -w\" \"nodemon dist/index.js\"",
 		"start": "node dist/index.js",
 		"test": "run-vitest"

--- a/apps/mail/package.json
+++ b/apps/mail/package.json
@@ -9,6 +9,7 @@
 		"build": "tsc",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"dev": "concurrently \"tsc -w\" \"nodemon dist/index.js\"",
 		"start": "node dist/index.js",
 		"test": "run-vitest"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
 		"build": "vite build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf node_modules .tanstack .turbo",
 		"dev": "vite dev --port=3000",
 		"preview": "vite preview",
 		"test": "run-vitest"

--- a/packages/app-client/package.json
+++ b/packages/app-client/package.json
@@ -13,6 +13,7 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "vitest run"
 	},
 	"dependencies": {},

--- a/packages/app-db/package.json
+++ b/packages/app-db/package.json
@@ -17,6 +17,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/audit-db/package.json
+++ b/packages/audit-db/package.json
@@ -21,6 +21,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/audit-sdk/package.json
+++ b/packages/audit-sdk/package.json
@@ -26,6 +26,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"docs:generate": "typedoc src/index.ts --out docs --theme default",
 		"test": "run-vitest"
 	},

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -14,6 +14,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/auth-db/package.json
+++ b/packages/auth-db/package.json
@@ -17,6 +17,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,6 +14,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/cerbos/package.json
+++ b/packages/cerbos/package.json
@@ -14,6 +14,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/fhir/package.json
+++ b/packages/fhir/package.json
@@ -14,6 +14,7 @@
 		"build": "tsc",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/hono-helpers/package.json
+++ b/packages/hono-helpers/package.json
@@ -14,6 +14,7 @@
 		"build": "tsc --build",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/infisical-kms/package.json
+++ b/packages/infisical-kms/package.json
@@ -12,6 +12,7 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"check:lint": "eslint . --ext .ts,.tsx",
 		"check:types": "tsc --noEmit",
+		"clean": "rm -rf dist node_modules .turbo",
 		"coverage": "vitest run --coverage",
 		"dev": "tsup src/index.ts --format cjs,esm --dts --watch",
 		"test": "vitest run",

--- a/packages/infisical/package.json
+++ b/packages/infisical/package.json
@@ -12,6 +12,7 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"check:lint": "eslint . --ext .ts,.tsx",
 		"check:types": "tsc --noEmit",
+		"clean": "rm -rf dist node_modules .turbo",
 		"dev": "tsup src/index.ts --format cjs,esm --dts --watch",
 		"test": "vitest run",
 		"test:ci": "vitest run --coverage",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -12,6 +12,7 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"check:lint": "eslint . --ext .ts,.tsx",
 		"check:types": "tsc --noEmit",
+		"clean": "rm -rf dist node_modules .turbo",
 		"dev": "tsup src/index.ts --format cjs,esm --watch"
 	},
 	"dependencies": {

--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -15,6 +15,7 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/send-mail/package.json
+++ b/packages/send-mail/package.json
@@ -15,7 +15,7 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
-		"clean": "rm -rf dist node_modules",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/smart-client/package.json
+++ b/packages/smart-client/package.json
@@ -15,6 +15,7 @@
 		"build": "tsc --build",
 		"check:lint": "eslint . --ext .ts,.tsx",
 		"check:types": "tsc --noEmit",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {

--- a/packages/workspace-dependencies/package.json
+++ b/packages/workspace-dependencies/package.json
@@ -38,6 +38,7 @@
 		"build": "runx build lib zx.ts yaml.ts zod.ts slugify.ts -d src -f cjs --platform node",
 		"check:lint": "run-eslint",
 		"check:types": "run-tsc",
+		"clean": "rm -rf dist node_modules .turbo",
 		"test": "run-vitest"
 	},
 	"dependencies": {


### PR DESCRIPTION
Add standardized "clean" npm scripts across apps and packages to remove build artifacts, node_modules, and framework-specific caches (e.g., .turbo, .tanstack, .mastra). This ensures consistent environment maintenance and simplifies cleanup operations across the monorepo.